### PR TITLE
Поддержка очень больших разрешений

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.ptx
 *.ptx.c
 *_g
+*.obj
 \#*
 .\#*
 /.config
@@ -37,3 +38,4 @@
 /src
 /mapfile
 /tools/python/__pycache__/
+/install

--- a/libavcodec/mjpegdec.c
+++ b/libavcodec/mjpegdec.c
@@ -342,10 +342,27 @@ int ff_mjpeg_decode_sof(MJpegDecodeContext *s)
       width = 2560;
     }
     if (width == 0) {
-      width = 2048;
+      if (height == 112) {
+        width = 4096;
+      } else {
+        width = 2048;
+      }
     }
     if (width == 544) {
       width = 2592;
+    }
+    if (width == 1792) {
+      width = 3840;
+    }
+    if (width == 1952) {
+      width = 4000;
+    }
+
+    if (height == 112) {
+      height = 2160;
+    }
+    if (height == 952) {
+      height = 3000;
     }
 
     // HACK for odd_height.mov


### PR DESCRIPTION
https://jira.smuit.ru/browse/NAVI-1090

Добавлены разрешения 4000х3000, 4096х2160, 3840х2160.
Но 4000х3000 выдает мне черный экран с самой камеры на веб-интерфейса, поэтому не знаю, как оно будет работать.